### PR TITLE
Use OS standard for default location of config

### DIFF
--- a/src/toolmaker/__init__.py
+++ b/src/toolmaker/__init__.py
@@ -5,6 +5,7 @@
 
 
 from . import _meta
+from . import core
 
 
 # PEP 396

--- a/src/toolmaker/cli.py
+++ b/src/toolmaker/cli.py
@@ -7,7 +7,6 @@
 import argparse
 import configparser
 import logging
-import pathlib
 
 from . import _meta
 from . import core
@@ -60,9 +59,7 @@ def main():
     logger = logging.getLogger(__name__)
     logging.basicConfig(level=logging.INFO)
 
-    cwd_path = pathlib.Path.cwd()
-    default_config_file_name = '{}.cfg'.format(_meta.PROJECT_NAME)
-    default_config_path = cwd_path.joinpath(default_config_file_name)
+    default_config_path = core.get_default_config_file_path()
 
     args_parser = _create_args_parser(default_config_path)
     args = args_parser.parse_args()

--- a/src/toolmaker/core.py
+++ b/src/toolmaker/core.py
@@ -205,4 +205,27 @@ def delete(config, tools_names):
                         raise
 
 
+def get_default_config_file_path():
+    """ Get default path for configuration file
+        Depends on the operating system.
+    """
+    file_name = 'toolmaker.cfg'
+    dir_name = _meta.PROJECT_NAME
+    path = None
+    config_path = None
+    if os.name == 'nt':
+        if 'APPDATA' in os.environ:
+            config_path = pathlib.Path(os.environ['APPDATA'])
+        else:
+            config_path = pathlib.Path.home().joinpath('AppData', 'Roaming')
+    elif os.name == 'posix':
+        if 'XDG_CONFIG_HOME' in os.environ:
+            config_path = pathlib.Path(os.environ['XDG_CONFIG_HOME'])
+        else:
+            config_path = pathlib.Path.home().joinpath('.config')
+    if config_path:
+        path = config_path.joinpath(dir_name, file_name)
+    return path
+
+
 # EOF


### PR DESCRIPTION
OSes have standards for default location of configuration files.
For example 'XDG_CONFIG_HOME' on Linux and 'APPDATA' on Windows.